### PR TITLE
perf: AES 加密固定 IV 参数，支持标准 aes-128-cbc 加解密格式(#28)

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -12,10 +12,10 @@ if (!fs.existsSync(data_dir)) fs.mkdirSync(data_dir);
 
 var multer = require('multer');
 var forms = multer({limits: { fieldSize: 100*1024*1024 }});
-app.use(forms.array()); 
+app.use(forms.array());
 
 const bodyParser = require('body-parser')
-app.use(bodyParser.json({limit : '50mb' }));  
+app.use(bodyParser.json({limit : '50mb' }));
 app.use(bodyParser.urlencoded({ extended: true }));
 
 const api_root = process.env.API_ROOT ? process.env.API_ROOT.trim().replace(/\/+$/, '') : '';
@@ -26,16 +26,16 @@ app.all(`${api_root}/`, (req, res) => {
 });
 
 app.post(`${api_root}/update`, (req, res) => {
-    const { encrypted, uuid } = req.body;
+    const { encrypted, uuid, iv = false } = req.body;
     // none of the fields can be empty
     if (!encrypted || !uuid) {
         res.status(400).send('Bad Request');
         return;
     }
 
-    // save encrypted to uuid file 
+    // save encrypted to uuid file
     const file_path = path.join(data_dir, path.basename(uuid)+'.json');
-    const content = JSON.stringify({"encrypted":encrypted});
+    const content = JSON.stringify({ encrypted, iv });
     fs.writeFileSync(file_path, content);
     if( fs.readFileSync(file_path) == content )
         res.json({"action":"done"});
@@ -67,7 +67,7 @@ app.all(`${api_root}/get/:uuid`, (req, res) => {
         // 如果传递了password，则返回解密后的数据
         if( req.body.password )
         {
-            const parsed = cookie_decrypt( uuid, data.encrypted, req.body.password );
+            const parsed = cookie_decrypt( uuid, data.encrypted, req.body.password, data.iv);
             res.json(parsed);
         }else
         {
@@ -88,12 +88,16 @@ app.listen(port, () => {
     console.log(`Server start on http://localhost:${port}${api_root}`);
 });
 
-function cookie_decrypt( uuid, encrypted, password )
+function cookie_decrypt( uuid, encrypted, password, iv = false)
 {
     const CryptoJS = require('crypto-js');
     const the_key = CryptoJS.MD5(uuid+'-'+password).toString().substring(0,16);
-    const decrypted = CryptoJS.AES.decrypt(encrypted, the_key).toString(CryptoJS.enc.Utf8);
+    const options = {
+        iv: CryptoJS.enc.Utf8.parse('0000000000000000'),
+        mode: CryptoJS.mode.CBC,
+        padding: CryptoJS.pad.Pkcs7
+    };
+    const decrypted = CryptoJS.AES.decrypt(encrypted, the_key, iv ? options : void 0).toString(CryptoJS.enc.Utf8);
     const parsed = JSON.parse(decrypted);
     return parsed;
 }
-  

--- a/extension/function.js
+++ b/extension/function.js
@@ -172,11 +172,16 @@ export async function upload_cookie( payload )
         console.log("error", error);
         showBadge("err");
         return false;
-    } 
+    }
     // 用aes对cookie进行加密
     const the_key = CryptoJS.MD5(payload['uuid']+'-'+payload['password']).toString().substring(0,16);
     const data_to_encrypt = JSON.stringify({"cookie_data":cookies,"local_storage_data":local_storages,"update_time":new Date()});
-    const encrypted = CryptoJS.AES.encrypt(data_to_encrypt, the_key).toString();
+    const options = {
+        iv: CryptoJS.enc.Utf8.parse('0000000000000000'),
+        mode: CryptoJS.mode.CBC,
+        padding: CryptoJS.pad.Pkcs7
+    };
+    const encrypted = CryptoJS.AES.encrypt(data_to_encrypt, the_key, options).toString();
     const endpoint = payload['endpoint'].trim().replace(/\/+$/, '')+'/update';
 
     // get sha256 of the encrypted data
@@ -189,10 +194,11 @@ export async function upload_cookie( payload )
         console.log("same data in 24 hours, skip1");
         return {action:'done',note:'本地Cookie数据无变动，不再上传'};
     }
-    
+
     const payload2 = {
             uuid: payload['uuid'],
-            encrypted: encrypted
+            encrypted: encrypted,
+            iv: true
     };
     // console.log( endpoint, payload2 );
     try {
@@ -204,15 +210,15 @@ export async function upload_cookie( payload )
         });
         const result = await response.json();
 
-        if( result && result.action === 'done' ) 
-            await save_data( 'LAST_UPLOADED_COOKIE', {"timestamp": new Date().getTime(), "sha256":sha256 } );    
+        if( result && result.action === 'done' )
+            await save_data( 'LAST_UPLOADED_COOKIE', {"timestamp": new Date().getTime(), "sha256":sha256 } );
 
         return result;
     } catch (error) {
         console.log("error", error);
         showBadge("err");
         return false;
-    }  
+    }
 }
 
 export async function download_cookie(payload)
@@ -230,7 +236,7 @@ export async function download_cookie(payload)
         const result = await response.json();
         if( result && result.encrypted )
         {
-            const { cookie_data, local_storage_data } = cookie_decrypt( uuid, result.encrypted, password );
+            const { cookie_data, local_storage_data } = cookie_decrypt( uuid, result.encrypted, password, result.iv);
             let action = 'done';
             if(cookie_data)
             {
@@ -262,8 +268,8 @@ export async function download_cookie(payload)
                                 showBadge("err");
                                 console.log("set cookie error", error);
                             }
-                            
-                            
+
+
                         }
                     }
                 }
@@ -292,11 +298,16 @@ export async function download_cookie(payload)
     }
 }
 
-function cookie_decrypt( uuid, encrypted, password )
+function cookie_decrypt( uuid, encrypted, password, iv = false)
 {
     const CryptoJS = require('crypto-js');
     const the_key = CryptoJS.MD5(uuid+'-'+password).toString().substring(0,16);
-    const decrypted = CryptoJS.AES.decrypt(encrypted, the_key).toString(CryptoJS.enc.Utf8);
+    const options = {
+        iv: CryptoJS.enc.Utf8.parse('0000000000000000'),
+        mode: CryptoJS.mode.CBC,
+        padding: CryptoJS.pad.Pkcs7
+      };
+    const decrypted = CryptoJS.AES.decrypt(encrypted, the_key, iv ? options : void 0).toString(CryptoJS.enc.Utf8);
     const parsed = JSON.parse(decrypted);
     return parsed;
 }
@@ -342,7 +353,7 @@ async function get_cookie_by_domains( domains = [], blacklist = [] )
                     {
                         ret_cookies[domain].push( cookie );
                     }
-                }    
+                }
             }
         }
         else
@@ -353,7 +364,7 @@ async function get_cookie_by_domains( domains = [], blacklist = [] )
                 // console.log("the cookie", cookie);
                 if( cookie.domain )
                 {
-                    
+
                     let in_blacklist = false;
                     for( const black of blacklist )
                     {
@@ -373,16 +384,16 @@ async function get_cookie_by_domains( domains = [], blacklist = [] )
                         ret_cookies[cookie.domain].push( cookie );
                     }
                 }
-                
+
             }
         }
-        
+
     }
     // console.log( "ret_cookies", ret_cookies );
     return ret_cookies;
 }
 
-function buildUrl(secure, domain, path) 
+function buildUrl(secure, domain, path)
 {
     if (domain.startsWith('.')) {
         domain = domain.substr(1);


### PR DESCRIPTION
具体原因见 #28 。主要修改点：

- AES 加密增加 iv 参数
- 兼容旧版本插件、旧版本保存的格式（根据是否有 iv 标记识别）
- 支持任意编程语言均可基于标准  `aes-128-cbc` 使用 iv=`0000000000000000` 进行解密

