### PR TITLE
add self-hosted address

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ We apologize for any inconvenience this may cause 🙇🏻‍♂️
 - <https://cookiecloud.25wz.cn> provided by [wuquejs](https://github.com/wuquejs)
 - <https://cookiecloud.zhensnow.uk> provided by [YeTianXingShi](https://github.com/YeTianXingShi)
 - <https://cookiecloud.ddsrem.com> provided by [DDSRem](https://github.com/DDS-Derek)
+- <https://cookiecloud.d0zingcat.xyz> provided by [d0zingcat](https://github.com/d0zingcat)
 
 ### Self-hosting
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -55,6 +55,7 @@ CookieCloud是一个和自架服务器同步Cookie的小工具，可以将浏览
 - <https://cookiecloud.25wz.cn> 由[wuquejs](https://github.com/wuquejs)提供
 - <https://cookiecloud.zhensnow.uk> 由[YeTianXingShi](https://github.com/YeTianXingShi)提供
 - <https://cookiecloud.ddsrem.com> 由[DDSRem](https://github.com/DDS-Derek)提供
+- <https://cookiecloud.d0zingcat.xyz> 由[d0zingcat](https://github.com/d0zingcat)提供
 
 ### 自行架设
 


### PR DESCRIPTION
I would like to make my self-hosted CookieCloud available publicly for those who need it, and I promise to maintain it for at least one year.