### PR TITLE
allow retrieving partitioned cookies

### DIFF
--- a/extension/function.js
+++ b/extension/function.js
@@ -337,7 +337,7 @@ async function get_cookie_by_domains( domains = [], blacklist = [] )
     // 获取cookie
     if( browser.cookies )
     {
-        const cookies = await browser.cookies.getAll({});
+        const cookies = await browser.cookies.getAll({ partitionKey: {} });
         // console.log("cookies", cookies);
         if( Array.isArray(domains) && domains.length > 0 )
         {


### PR DESCRIPTION
Fix: https://github.com/easychen/CookieCloud/issues/63

See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll#partitionkey :

`If included without `topLevelSite', all cookies from partitioned and unpartitioned storage are returned.`