### PR TITLE
fix #105

### DIFF
--- a/extension/function.js
+++ b/extension/function.js
@@ -150,7 +150,7 @@ export async function upload_cookie( payload )
     const blacklist = payload['blacklist']?.trim().length > 0 ? payload['blacklist']?.trim().split("\n") : [];
 
     const cookies = await get_cookie_by_domains( domains, blacklist );
-    const with_storage = payload['with_storage'] || 0;
+    const with_storage = Number(payload['with_storage']) === 1;
     const local_storages = with_storage ? await get_local_storage_by_domains( domains ) : {};
 
     let headers = { 'Content-Type': 'application/json', 'Content-Encoding': 'gzip' }


### PR DESCRIPTION
修复 localStorage 选项不生效问题.

# 解释
- popup 的设置里会导致选项值为字符串
https://github.com/easychen/CookieCloud/blob/879efacbebfefe51f11155ac35327242c9d9ac79/extension/popup.tsx#L137-L146
- 上传逻辑中对类型对比有误，`'0'` 会转换成`true`
https://github.com/easychen/CookieCloud/blob/879efacbebfefe51f11155ac35327242c9d9ac79/extension/function.js#L153-L154