### PR TITLE
fix #88 修正异常时的返回值类型，供下游正确解析，以反馈给用户

### DIFF
--- a/extension/function.js
+++ b/extension/function.js
@@ -143,7 +143,7 @@ export async function upload_cookie( payload )
     if (!password || !uuid) {
         alert("错误的参数");
         showBadge("err");
-        return false;
+        return { action: false, note: "错误的参数" };
     }
     const domains = payload['domains']?.trim().length > 0 ? payload['domains']?.trim().split("\n") : [];
 
@@ -171,7 +171,7 @@ export async function upload_cookie( payload )
     } catch (error) {
         console.log("error", error);
         showBadge("err");
-        return false;
+        return { action: false, note: error.message };
     } 
     // 用aes对cookie进行加密
     const the_key = CryptoJS.MD5(payload['uuid']+'-'+payload['password']).toString().substring(0,16);
@@ -211,7 +211,7 @@ export async function upload_cookie( payload )
     } catch (error) {
         console.log("error", error);
         showBadge("err");
-        return false;
+        return { action: false, note: error.message };
     }  
 }
 
@@ -297,7 +297,7 @@ export async function download_cookie(payload)
     } catch (error) {
         console.log("error", error);
         showBadge("err");
-        return false;
+        return { action: false, note: error.message };
     }
 }
 


### PR DESCRIPTION
统一返回值数据结构，以便向下正常透传，供交互反馈正确解析。

# 解释
- 视图层触发上传、下载逻辑时，与背景页交互，期待的返回结果是
```json5
// ret
{
  message: 'xxx', // 'done' 或其他值
  note: 'xxx',
}
```
https://github.com/easychen/CookieCloud/blob/e631fa94f25e58a93f41aff37a3b46e1cd6755e9/extension/popup.tsx#L13-L39

- 背景页响应时,会有个字段名的映射转换: `action`对应`message`
https://github.com/easychen/CookieCloud/blob/e631fa94f25e58a93f41aff37a3b46e1cd6755e9/extension/background/messages/config.ts#L14-L23

- 本次修改将`upload_cookie()`、`download_cookie()`的异常时的返回值数据结构统一成:
```json5
{
  action: 'xxx',
  note: 'xxx'
}
```