### PR TITLE
feat: 增加严格域名匹配选项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/
 logs/
 ref/
 .DS_Store
+Plan.md

--- a/ext/entrypoints/content.ts
+++ b/ext/entrypoints/content.ts
@@ -9,14 +9,23 @@ export default defineContentScript({
       // Get current domain
       const host = window.location.hostname;
       const config = await load_data("COOKIE_SYNC_SETTING");
-      if (config?.domains) {
-        const domains = config.domains?.trim().split("\n");
-        // Check if domain partially matches each domain in domains
+      const domains = (config?.domains ?? '')
+        .split("\n")
+        .map((line: string) => line.trim())
+        .filter((line: string) => line.length > 0);
+      if (domains.length > 0) {
+        const strict_domain = Number(config?.strict_domain) === 1;
+        const host_normalized = host.trim().toLowerCase().replace(/^\./, '');
         let matched = false;
         for (const domain of domains) {
-          if (host.includes(domain)) matched = true;
+          const domain_normalized = domain.trim().toLowerCase().replace(/^\./, '');
+          if (strict_domain) {
+            if (host_normalized === domain_normalized) matched = true;
+          } else {
+            if (host.includes(domain)) matched = true;
+          }
         }
-        if (domains.length > 0 && !matched) return false;
+        if (!matched) return false;
       }
 
       if (config?.type && config.type == 'down') {

--- a/ext/entrypoints/popup/App.tsx
+++ b/ext/entrypoints/popup/App.tsx
@@ -21,6 +21,7 @@ interface ConfigData {
   type: string;
   keep_live: string;
   with_storage: number;
+  strict_domain: number;
   blacklist: string;
   headers: string;
   expire_minutes: number;
@@ -37,6 +38,7 @@ const CookieCloudPopup: React.FC = () => {
     type: "up",
     keep_live: "",
     with_storage: 1,
+    strict_domain: 0,
     blacklist: "google.com",
     headers: "",
     expire_minutes: 60 * 24 * 365,
@@ -379,6 +381,40 @@ const CookieCloudPopup: React.FC = () => {
                       value={data.domains}
                       onChange={(e) => handleInputChange('domains', e.target.value)}
                     />
+                  </div>
+
+                  {/* Strict Domain Match */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">
+                      {browser.i18n.getMessage('strictDomainMatch') || '严格域名匹配（不含子域）'}
+                    </label>
+                    <div className="flex items-center space-x-6">
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name="strict_domain"
+                          value="1"
+                          checked={data.strict_domain === 1}
+                          onChange={(e) => handleInputChange('strict_domain', parseInt(e.target.value))}
+                          className="mr-2"
+                        />
+                        {browser.i18n.getMessage('yes') || '是'}
+                      </label>
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name="strict_domain"
+                          value="0"
+                          checked={data.strict_domain === 0}
+                          onChange={(e) => handleInputChange('strict_domain', parseInt(e.target.value))}
+                          className="mr-2"
+                        />
+                        {browser.i18n.getMessage('no') || '否'}
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-500 mt-1">
+                      {browser.i18n.getMessage('strictDomainMatchDesc') || '开启后域名关键词按完全相等匹配，不包含子域'}
+                    </p>
                   </div>
 
                   {/* Blacklist */}

--- a/ext/public/_locales/en/messages.json
+++ b/ext/public/_locales/en/messages.json
@@ -96,6 +96,12 @@
     "syncDomainKeywordPlaceholder": {
         "message": "One per line, sync all domains containing the keyword, e.g., qq.com, jd.com will include all subdomains, leave blank to sync all by default"
     },
+    "strictDomainMatch": {
+        "message": "Strict domain match (no subdomains)"
+    },
+    "strictDomainMatchDesc": {
+        "message": "When enabled, domain keywords are matched by exact equality and will not include subdomains"
+    },
     "syncDomainBlacklist": {
         "message": "Sync Domain Blacklist · Optional"
     },

--- a/ext/public/_locales/zh_CN/messages.json
+++ b/ext/public/_locales/zh_CN/messages.json
@@ -124,6 +124,14 @@
     {
         "message":"一行一个，同步包含关键词的全部域名，如qq.com,jd.com会包含全部子域名，留空默认同步全部"
     },
+    "strictDomainMatch":
+    {
+        "message":"严格域名匹配（不含子域）"
+    },
+    "strictDomainMatchDesc":
+    {
+        "message":"开启后域名关键词按完全相等匹配，仅同步该域名本身，不包含子域"
+    },
     "syncDomainBlacklist":
     {
         "message":"同步域名黑名单·选填"

--- a/extension/content.ts
+++ b/extension/content.ts
@@ -7,16 +7,25 @@ window.addEventListener("load", async () => {
     // 获得当前域名
     const host = window.location.hostname;
     const config = await load_data("COOKIE_SYNC_SETTING") ;
-    if( config?.domains )
+    const domains = String(config?.domains||'').split("\n").map( line => line.trim() ).filter( line => line.length > 0 );
+    if( domains.length > 0 )
     {
-        const domains = config.domains?.trim().split("\n");
-        // 检查 domain 是否部分匹配 domains的每一个域名
+        const host_normalized = host.trim().toLowerCase().replace(/^\./, '');
+        // 检查 domain 是否匹配 domains的每一个域名
         let matched = false;
+        const strict_domain = Number(config?.strict_domain) === 1;
         for(const domain of domains)
         {
-            if( host.includes(domain) ) matched = true;
+            const domain_normalized = String(domain).trim().toLowerCase().replace(/^\./, '');
+            if( strict_domain )
+            {
+                if( host_normalized === domain_normalized ) matched = true;
+            }else
+            {
+                if( host.includes(domain) ) matched = true;
+            }
         }
-        if( domains.length > 0 && !matched ) return false;
+        if( !matched ) return false;
     }
 
     if( config?.type && config.type == 'down' )

--- a/extension/locales/en/messages.json
+++ b/extension/locales/en/messages.json
@@ -96,6 +96,12 @@
     "syncDomainKeywordPlaceholder": {
         "message": "One per line, sync all domains containing the keyword, e.g., qq.com, jd.com will include all subdomains, leave blank to sync all by default"
     },
+    "strictDomainMatch": {
+        "message": "Strict domain match (no subdomains)"
+    },
+    "strictDomainMatchDesc": {
+        "message": "When enabled, domain keywords are matched by exact equality and will not include subdomains"
+    },
     "syncDomainBlacklist": {
         "message": "Sync Domain Blacklist · Optional"
     },

--- a/extension/locales/zh_CN/messages.json
+++ b/extension/locales/zh_CN/messages.json
@@ -124,6 +124,14 @@
     {
         "message":"一行一个，同步包含关键词的全部域名，如qq.com,jd.com会包含全部子域名，留空默认同步全部"
     },
+    "strictDomainMatch":
+    {
+        "message":"严格域名匹配（不含子域）"
+    },
+    "strictDomainMatchDesc":
+    {
+        "message":"开启后域名关键词按完全相等匹配，仅同步该域名本身，不包含子域"
+    },
     "syncDomainBlacklist":
     {
         "message":"同步域名黑名单·选填"

--- a/extension/popup.tsx
+++ b/extension/popup.tsx
@@ -7,7 +7,7 @@ import { load_data, save_data } from './function';
 import browser from 'webextension-polyfill';
 
 function IndexPopup() {
-  let init: Object={"endpoint":"http://127.0.0.1:8088","password":"","interval":10,"domains":"","uuid":String(short_uid.generate()),"type":"up","keep_live":"","with_storage":1,"blacklist":"google.com", "headers": "","expire_minutes":60*24*365};
+  let init: Object={"endpoint":"http://127.0.0.1:8088","password":"","interval":10,"domains":"","uuid":String(short_uid.generate()),"type":"up","keep_live":"","with_storage":1,"strict_domain":0,"blacklist":"google.com", "headers": "","expire_minutes":60*24*365};
   const [data, setData] = useState(init);
   
   async function test(action=browser.i18n.getMessage('test'))
@@ -150,6 +150,13 @@ function IndexPopup() {
 
         <div className="">{browser.i18n.getMessage('syncDomainKeyword')}</div>
         <textarea className="border-1  my-2 p-2 rounded w-full" style={{"height":"60px"}} placeholder={browser.i18n.getMessage('syncDomainKeywordPlaceholder')}  onChange={e=>onChange('domains',e)} value={data['domains']}/>
+
+        <div className="">{browser.i18n.getMessage('strictDomainMatch') || '严格域名匹配（不含子域）'}</div>
+        <div className="my-2 flex flex-row items-center">
+        <label className="mr-2"><input type="radio" name="strict_domain" value="1" checked={data['strict_domain'] == 1} onChange={e=>onChange('strict_domain',e)} /> {browser.i18n.getMessage('yes')}</label>
+        <label className="mr-2"><input type="radio" name="strict_domain" value="0" checked={data['strict_domain'] == 0 || !data['strict_domain']} onChange={e=>onChange('strict_domain',e)} /> {browser.i18n.getMessage('no')}</label>
+        </div>
+        <div className="text-gray-400 text-xs">{browser.i18n.getMessage('strictDomainMatchDesc') || '开启后域名关键词按完全相等匹配，不包含子域'}</div>
 
         <div className="">{browser.i18n.getMessage('syncDomainBlacklist')}</div>
         <textarea className="border-1  my-2 p-2 rounded w-full" style={{"height":"60px"}} placeholder={browser.i18n.getMessage('syncDomainBlacklistPlaceholder')}  onChange={e=>onChange('blacklist',e)} value={data['blacklist']}/>


### PR DESCRIPTION
之所以要严格域名，是因为有的站点比如[蟹黄堡](crabpt.vip) 除了原始域名之外还包含一些二级站点比如阅读、音乐。而不严格保存域名关键字里的cookie的话，也会把二级站点内的cookie保存进去，mp在同步的时候用包含全部的cookie会报错：cookie失效